### PR TITLE
Fix the dooble.sh install path for FreeBSD

### DIFF
--- a/Version 1.x/dooble.freebsd.clang.qt5.pro
+++ b/Version 1.x/dooble.freebsd.clang.qt5.pro
@@ -241,7 +241,7 @@ TARGET		= Dooble
 
 dooble.path		= /usr/local/dooble
 dooble.files		= Dooble
-dooble_sh.path		= /usr/local/dooble
+dooble_sh.path		= /usr/local/bin
 dooble_sh.files		= dooble.sh
 desktop.path            = /usr/share/applications
 desktop.files           = dooble.desktop


### PR DESCRIPTION
Move the dooble.sh startup script into /usr/local/bin on FreeBSD so that it is identified as the binary to launch the browser. 