### PR TITLE
Fix build with Qt 6.6

### DIFF
--- a/Source/dooble_downloads.cc
+++ b/Source/dooble_downloads.cc
@@ -224,7 +224,7 @@ void dooble_downloads::create_tables(QSqlDatabase &db)
 {
   db.open();
 
-  QSqlDatabase query(db);
+  QSqlQuery query(db);
 
   query.exec("CREATE TABLE IF NOT EXISTS dooble_downloads ("
 	     "download_path TEXT NOT NULL, "


### PR DESCRIPTION
QSqlDataBase::exec() has had a deprecation note in the documentation for 12 years and the function has been finally marked as such in Qt 6.6. With -Werror enabled, the build fails due to the deprecation warning.