### PR TITLE
Add more qmake cxx flag.

### DIFF
--- a/dooble.pro
+++ b/dooble.pro
@@ -274,6 +274,7 @@ QMAKE_CXXFLAGS_RELEASE += -O3 \
                           -Werror \
                           -Wextra \
                           -Wformat=2 \
+                          -Wold-style-cast \
                           -Woverloaded-virtual \
                           -Wpointer-arith \
                           -Wstack-protector \
@@ -294,6 +295,7 @@ QMAKE_CXXFLAGS_RELEASE += -O3 \
                           -Wcast-qual \
                           -Wextra \
                           -Wformat=2 \
+                          -Wold-style-cast \
                           -Woverloaded-virtual \
                           -Wpointer-arith \
                           -Wstack-protector \
@@ -327,6 +329,7 @@ QMAKE_CXXFLAGS_RELEASE += -O3 \
                           -Wformat=2 \
                           -Wlogical-op \
                           -Wno-deprecated-copy \
+                          -Wold-style-cast \
                           -Woverloaded-virtual \
                           -Wpointer-arith \
                           -Wstack-protector \


### PR DESCRIPTION
### What:
Encouraging the use of c++ cast / named cast.
### Why:
Readability. Error avoidance. Named casts are more specific than a C-style or functional cast, allowing the compiler to catch some errors.
### How:
Add cxx flag to enforce this, but the flag is not enforce C-style cast to void, see [documentation](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wold-style-cast).